### PR TITLE
Fix tile outside SB issue. Now checks if tile is outside SB and if so returns a NaN tile

### DIFF
--- a/hpx_tiles/casa_tiling.py
+++ b/hpx_tiles/casa_tiling.py
@@ -17,12 +17,98 @@ import time
 import argparse
 import logging
 from casatasks import imhead, imregrid, exportfits
-
+from astropy import units as u
+from astropy_healpix import HEALPix
+from regions import Regions
+from astropy.io import fits
+from astropy import wcs
 
 logging.basicConfig(level=logging.INFO)
 
+def tileID_to_region(tileID):
+    """@Erik Osinga
+    Input; tile ID
+    Returns: Regions object (i.e. region) denoting the tile with hpx number "tileID"
+    """
+    Nside=32
+    HPX_PIXEL = tileID
+    hp = HEALPix(nside=Nside, order='ring', frame='icrs')
+    corner = hp.boundaries_lonlat(HPX_PIXEL, step=1) * u.deg
+    RA, DEC = corner.value
+    RA = RA[0]
+    DEC = DEC[0]
+    polygon_string = 'polygon(%f, %f, %f, %f, %f, %f, %f, %f)'%(RA[0], DEC[0],  RA[1], DEC[1], RA[2], DEC[2], RA[3], DEC[3])    
+    with open("regionfile.reg", 'w') as f:
+        f.write('# Region file format: DS9 astropy/regions')
+        f.write('\n')
+        f.write('fk5')
+        f.write('\n')        
+        f.write(polygon_string)
 
-def parse_args(argv):
+    r = Regions.read("regionfile.reg")
+    # clean up region file again
+    os.system("rm regionfile.reg")
+
+    return r
+
+def mask_regions(fitsimage, region, maskoutside=True):
+    """@Erik Osinga
+    Given a FITS image and a DS9 region file, mask the pixels based on the regions.
+    
+    Args:
+        fitsimage (str): Path to the FITS image file.
+        ds9region (str): Path to the DS9 region file.
+        maskoutside (bool): If True, mask everything outside the region.
+                            If False, mask everything inside the region.
+    
+    Returns:
+        np.ndarray: Masked data array, same shape as input fits image.
+    """
+    # Open the FITS file
+    with fits.open(fitsimage) as hdu:
+        # Read the region (assume its not a file but already a region object)
+        r = region
+        if len(r)>1:
+            raise ValueError(f"Expected one region file but found {len(r)}")
+        # Convert the region to a 2D pixel mask
+        rpix = r[0].to_pixel(wcs.WCS(hdu[0].header).celestial)
+        
+        # assumes final 2 axes are DEC,RA axis. 
+        # fits.open() reads in reverse order, so if first two fits axes are RA,DEC we're good
+        if ("RA" not in hdu[0].header['CTYPE1']) or ("DEC" not in hdu[0].header['CTYPE2']):
+            raise ValueError("Assumed first two axes are RA,DEC. But they are not.")
+
+        mask = rpix.to_mask().to_image(hdu[0].data.shape[-2:])
+
+        if mask is None:
+            # then the region is outside the image
+            # mask everything
+            if maskoutside:
+                mask = np.zeros(hdu[0].data.shape[-2:])
+            else:
+                mask = np.ones(hdu[0].data.shape[-2:])
+
+        naxes = hdu[0].header['naxis']
+
+        if maskoutside:
+            # Mask everything outside the region
+            setmaskto = 0
+        else:
+            # Mask everything inside the region
+            setmaskto = 1
+
+        if naxes == 4:
+            hdu[0].data[:, :, mask == setmaskto] = np.nan
+        elif naxes == 3:
+            hdu[0].data[:, mask == setmaskto] = np.nan
+        elif naxes == 2:
+            hdu[0].data[mask == setmaskto] = np.nan
+
+        data = hdu[0].data
+
+    return data
+
+def parse_args(argv):# 
     parser = argparse.ArgumentParser("Generate tiles for a specfic SB.")
     parser.add_argument("-i", dest="obs_id", help="Observation ID.", required=True)
     parser.add_argument("-c", dest="cube", help="Image cube.", required=True)
@@ -47,6 +133,57 @@ def parse_args(argv):
         default="PoSSUM",)
     args = parser.parse_args(argv)
     return args
+
+def create_nan_tile(original_image, template_fits, crpix1_and_2, outfile):
+    """@Erik Osinga
+    
+    Create a "tile" from an SB that's outside the tile using a template tile .fits file.
+        i.e. Creates a tile with all-NaNs with the same freq and stokes axis as the original_image.
+
+
+    original_image -- str       -- location of fits file of observation
+    template_fits  -- str       -- location of tile template fits file (i.e. correct projection and NAXIS1 and NAXIS2)
+    crpix1_and_2   -- [flt,flt] -- new value of CRPIX defining the centre of the tile
+    outfile        -- str       -- name of output file written
+
+    Simply masks the whole template tile .fits file and re-assign parameters CRPIX1 and CRPIX2
+    to those given by the user. Makes sure the other axes (freq,stokes) are the same as the original_imagae
+
+    Saves the result in a fitsfile "outfile"
+    """
+    # assumed values for CRPIX_1 (RA) CRPIX_2 (DEC)
+    crpix1, crpix2 = crpix1_and_2
+
+    with fits.open(original_image) as hdul_o:
+        with fits.open(template_fits) as hdul_t:
+            naxis_template = hdul_t[0].header['NAXIS']
+            naxis_original = hdul_o[0].header["NAXIS"]
+            
+            if naxis_original != naxis_template:
+                raise ValueError(f"Please provide template file with same naxis as input cube. Currently its {naxis_template} vs {naxis_original}")
+
+            # assumes last two axes are always RA,DEC
+            shape_o = hdul_o[0].data.shape[:-2]
+            shape_t = hdul_t[0].data.shape[2:]
+            # new tile should be same RA,DEC shape as template, but freq,stokes from original file
+            shape_new = shape_o + shape_t
+
+            # create NaN tile in correct shape
+            data_new = np.zeros(shape_new)*np.nan
+
+            # adjust header
+            hdul_t[0].header["CRPIX1"] = crpix1
+            hdul_t[0].header["CRPIX2"] = crpix2
+            for i in range(2,len(shape_new)):
+                # remember start counting at NAXIS1, so NAXIS3 is first non-angular coordinate
+                # and np.array() is inverted shape from fits header
+                # print(f"NAXIS{i+1} = {shape_new[::-1][i]}" )
+
+                hdul_t[0].header[f"NAXIS{i}"] = shape_new[::-1][i]
+                hdul_t[0].header[f"NAXIS{i}"] = shape_new[::-1][i]
+            
+            hdul_t[0].data = data_new
+            hdul_t[0].writeto(outfile, overwrite=False) # should be the first of its name
 
 
 def main(argv):
@@ -124,64 +261,84 @@ def main(argv):
         logging.info(f"Regridding tile {i+1}/{len(crpix1)}")
         one_tile_start = time.time()
 
-        try:
-            # this is how I will update the dictionary
-            template_header["csys"]["direction0"]["crpix"] = np.array([ra, dec])
+        # Update the template header dictionary from / for imregrid
+        template_header["csys"]["direction0"]["crpix"] = np.array([ra, dec])
 
-            if len(axis) == 4:
-                fourth_axis = axis[3]
-                if fourth_axis == "Frequency":
-                    number_of_frequency = fitsheader["shape"][3]
-                    template_header["shap"] = np.array(
-                        [naxis, naxis, 1, number_of_frequency])
+        output_filename = "%s_%s-%d.image" % (prefix, args.obs_id, pixel_ID[i])
+        output_name = os.path.join(write_dir, output_filename)
 
-                third_axis = axis[2]
-                if third_axis == "Frequency":
-                    number_of_frequency = fitsheader["shape"][2]
-                    template_header["shap"] = np.array(
-                        [naxis, naxis, number_of_frequency, 1])
+        ##############
+        # below lines added by Erik to 
+        # check if there are any non-NaN pixels in the tile region 
+        r = tileID_to_region(pixel_ID[i])
+        masked_data = mask_regions(image, r, maskoutside=True)
+        # if there are only NaN pixels, we don't need to make this tile from the current observation
+        # we can simply create a tile with all-NaN in case it needs to be combined with different freqs
+        if np.isnan(masked_data).all():
+            logging.warning("WARNING: Tile is outside the observation. If this is the case for all frequencies, then the tile does not actually require this observation.")
+            # todo: check/log this somehow? It would verify the radius needed for the tile
 
-            if len(axis) == 3:
-                third_axis = axis[2]
-                if third_axis == "Frequency":
-                    number_of_frequency = fitsheader["shape"][2]
-                    template_header["shap"] = np.array(
-                        [naxis, naxis, number_of_frequency])
-                else:
-                    template_header["shap"] = np.array([naxis, naxis, 1])
+            fitsimage=output_name.split(".image")[0] + ".fits"
+            logging.info(f"Creating NaN tile {fitsimage}")
+            create_nan_tile(image, tile_template, template_header["csys"]["direction0"]["crpix"], fitsimage)
+        ##############
 
-            output_filename = "%s_%s-%d.image" % (prefix, args.obs_id, pixel_ID[i])
-            output_name = os.path.join(write_dir, output_filename)
+        else: # if there are finite value pixels, proceed as before
 
-            # tiling, outputs tile fits in CASA image.
-            imregrid(
-                imagename=image,
-                template=template_header,
-                output=output_name,
-                axes=[0, 1],
-                interpolation="cubic",
-                overwrite=True,)
+            try:
+                if len(axis) == 4:
+                    fourth_axis = axis[3]
+                    if fourth_axis == "Frequency":
+                        number_of_frequency = fitsheader["shape"][3]
+                        template_header["shap"] = np.array(
+                            [naxis, naxis, 1, number_of_frequency])
 
-            # convert casa image to fits image
-            one_tile_end = time.time()
-            logging.info(
-                "Tiling of pixel ID %d completed. Time elapsed %.3f seconds. "
-                % (pixel_ID[i], (one_tile_end - one_tile_start)))
+                    third_axis = axis[2]
+                    if third_axis == "Frequency":
+                        number_of_frequency = fitsheader["shape"][2]
+                        template_header["shap"] = np.array(
+                            [naxis, naxis, number_of_frequency, 1])
 
-            logging.info("Converting the casa image to fits image.")
-            exportfits(
-                imagename=output_name,
-                fitsimage=output_name.split(".image")[0] + ".fits",
-                overwrite=True,
-                stokeslast=False)
+                if len(axis) == 3:
+                    third_axis = axis[2]
+                    if third_axis == "Frequency":
+                        number_of_frequency = fitsheader["shape"][2]
+                        template_header["shap"] = np.array(
+                            [naxis, naxis, number_of_frequency])
+                    else:
+                        template_header["shap"] = np.array([naxis, naxis, 1])
 
-            # delete all casa image files.
-            logging.info("Deleting the casa image. ")
-            os.system("rm -rf %s" % output_name)
-        except Exception as e:
-            logging.error(f"There was an exception: {e}")
-            logging.info("Skipping pixel")
-            # TODO: need to update csv file
+
+
+                # tiling, outputs tile fits in CASA image.
+                imregrid(
+                    imagename=image,
+                    template=template_header,
+                    output=output_name,
+                    axes=[0, 1],
+                    interpolation="cubic",
+                    overwrite=True,)
+
+                # convert casa image to fits image
+                one_tile_end = time.time()
+                logging.info(
+                    "Tiling of pixel ID %d completed. Time elapsed %.3f seconds. "
+                    % (pixel_ID[i], (one_tile_end - one_tile_start)))
+
+                logging.info("Converting the casa image to fits image.")
+                exportfits(
+                    imagename=output_name,
+                    fitsimage=output_name.split(".image")[0] + ".fits",
+                    overwrite=True,
+                    stokeslast=False)
+
+                # delete all casa image files.
+                logging.info("Deleting the casa image. ")
+                os.system("rm -rf %s" % output_name)
+            except Exception as e:
+                logging.error(f"There was an exception: {e}")
+                logging.info("Skipping tile")
+                # TODO: need to update csv file
 
     end_tiling = time.time()
     logging.info(


### PR DESCRIPTION
This updates the `casa_tiling.py` script with a check to see whether a tile is even part of an SB. Previously casa's `imregrid` would raise an error if an observation was attempted to be regridded onto a tile that's completely outside the observation. Now, it should check whether that's the case and if so, create an all-NAN tile with the same frequency axis as the original observation. This is done because I have heard that `casa_tiling.py` is called with different sub-bands, and some sub-bands might overlap with a tile, while higher frequencies might perhaps not overlap with a tile. Now the NaN tiles could be combined with non-NaN tiles across frequency to arrive at a consistent dataproduct containing the same number of channels. 



For reference, the imregrid error when trying to regrid outside an observation:
```
ERROR:root:There was an exception: Exception: All output pixels are masked. You might want to try decreasing the value of decimate if you are regridding direction axes.
```


Although this shouldn't be necessary if we put the know the exact beam radius (as a function of frequency) of every of the 36 ASKAP beams, that's probably hard to get exactly right. With this script, we can err on the side of caution and give a slightly larger radius at the cost of creating some NaN tiles. 